### PR TITLE
fix variable duplication, organize code, set initial planetary positions

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -5,14 +5,14 @@ let requestAnimationFrame = global.requestAnimationFrame;
 let renderer, scene, camera, controls, light, radians;
 let mouse = new THREE.Vector2();
 
-let milkyWay, theSun, mercury, venus, earth, mars, asteroidBelt, asteroid, jupiter, saturn, saturnRing, uranus, neptune;
+let milkyWay, theSun, asteroidBelt, asteroid, saturnRing, uranusRing;
 
 // planet/sun size = 100,000km : 50 units
 //      - The Sun is ~696342km, r = sunSize = 348.15,
 // AU = 150 mil km : 50 units
 // planet orbital radius = 1AU : 1AU
 //      - Mercury is 0.4AU from the Sun, thus
-//      mercuryOrbitRadius = sunSize + (AU * 0.4)
+//      planets.mercury.orbitalRadius = sunSize + (AU * 0.4)
 // planet orbit speed = 1km : 0.02 units
 
 let AU = 50;
@@ -21,62 +21,82 @@ let milkyWaySize = 15000;
 
 let sunSize = 348.15;
 
-let mercurySize = 1.2,
-    mercuryOrbitRadius = sunSize + (AU * 0.4),
-    mercuryOrbitAngle = getRandomNumber(0, 360),
-    mercuryOrbitSpeed = 0.8,
-    mercuryRotateSpeed = 0.05;
-
-let venusSize = 3,
-    venusOrbitRadius = sunSize + (AU * 0.7),
-    venusOrbitAngle = getRandomNumber(0, 360),
-    venusOrbitSpeed = 0.7,
-    venusRotateSpeed = 0.05;
-
-let earthSize = 3,
-    earthOrbitRadius = sunSize + AU,
-    earthOrbitAngle = getRandomNumber(0, 360),
-    earthOrbitSpeed = 0.6,
-    earthRotateSpeed = 0.05;
-
-let marsSize = 1.6,
-    marsOrbitRadius = sunSize + (AU * 1.5),
-    marsOrbitAngle = getRandomNumber(0, 360),
-    marsOrbitSpeed = 0.48,
-    marsRotateSpeed = 0.05;
+let planets = {
+    mercury: {
+        size: 1.2,
+        orbitalRadius: sunSize + (AU * 0.4),
+        angle: getRandomNumber(0, 360),
+        orbitalSpeed: 0.8,
+        rotationSpeed: 0.05,
+        meshSize: 15,
+    },
+    venus: {
+        size: 3,
+        orbitalRadius: sunSize + (AU * 0.7),
+        angle: getRandomNumber(0, 360),
+        orbitalSpeed: 0.7,
+        rotationSpeed: -0.05,
+        meshSize: 15,
+    },
+    earth: {
+        size: 3,
+        orbitalRadius: sunSize + AU,
+        angle: getRandomNumber(0, 360),
+        orbitalSpeed: 0.6,
+        rotationSpeed: 0.05,
+        meshSize: 15,
+    },
+    mars: {
+        size: 1.6,
+        orbitalRadius: sunSize + (AU * 1.5),
+        angle: getRandomNumber(0, 360),
+        orbitalSpeed: 0.48,
+        rotationSpeed: 0.05,
+        meshSize: 15,
+    },
+    jupiter: {
+        size: 34.99,
+        orbitalRadius: sunSize + (AU * 5.2),
+        angle: getRandomNumber(0, 360),
+        orbitalSpeed: 0.26,
+        rotationSpeed: 0.05,
+        meshSize: 25,
+    },
+    saturn: {
+        size: 29.1,
+        orbitalRadius: sunSize + (AU * 9.5),
+        angle: getRandomNumber(0, 360),
+        orbitalSpeed: 0.18,
+        rotationSpeed: 0.05,
+        meshSize: 25,
+    },
+    uranus: {
+        size: 12.7,
+        orbitalRadius: sunSize + (AU * 19.2),
+        angle: getRandomNumber(0, 360),
+        orbitalSpeed: 0.14,
+        rotationSpeed: -0.05,
+        meshSize: 20,
+      rotationAxis: 'x',
+    },
+    neptune: {
+        size: 12.3,
+        orbitalRadius: sunSize + (AU * 30.1),
+        angle: getRandomNumber(0, 360),
+        orbitalSpeed: 0.1,
+        rotationSpeed: 0.05,
+        meshSize: 20,
+    },
+};
 
 let asteroidOrbitStart = sunSize + (AU * 2.3),
     asteroidOrbitEnd = sunSize + (AU * 3.3);
 
-let jupiterSize = 34.99,
-    jupiterOrbitRadius = sunSize + (AU * 5.2),
-    jupiterOrbitAngle = getRandomNumber(0, 360),
-    jupiterOrbitSpeed = 0.26,
-    jupiterRotateSpeed = 0.05;
+let saturnRingStart = planets.saturn.size + 3.3,
+    saturnRingEnd = planets.saturn.size + 60;
 
-let saturnSize = 29.1,
-    saturnOrbitRadius = sunSize + (AU * 9.5),
-    saturnOrbitAngle = getRandomNumber(0, 360),
-    saturnOrbitSpeed = 0.18,
-    saturnRotateSpeed = 0.05;
-
-let saturnRingStart = saturnSize + 3.3,
-    saturnRingEnd = saturnSize + 60;
-
-let uranusSize = 12.7,
-    uranusOrbitRadius = sunSize + (AU * 19.2),
-    uranusOrbitAngle = getRandomNumber(0, 360),
-    uranusOrbitSpeed = 0.14,
-    uranusRotateSpeed = 0.05;
-
-let uranusRingStart = uranusSize + 3,
-    uranusRingEnd = uranusSize + 40;
-
-let neptuneSize = 12.3,
-    neptuneOrbitRadius = sunSize + (AU * 30.1),
-    neptuneOrbitAngle = getRandomNumber(0, 360),
-    neptuneOrbitSpeed = 0.1,
-    neptuneRotateSpeed = 0.05;
+let uranusRingStart = planets.uranus.size + 3,
+    uranusRingEnd = planets.uranus.size + 40;
 
 let WIDTH = window.innerWidth,
     HEIGHT = window.innerHeight;
@@ -146,21 +166,12 @@ function init() {
     theSun = createBasicMesh('assets/images/sun.jpg', sunSize, 35);
     scene.add(theSun);
 
-    //Mercury
-    mercury = createLambertMesh('assets/images/mercury.jpg', mercurySize, 15);
-    scene.add(mercury);
-
-    //Venus
-    venus = createLambertMesh('assets/images/venus.jpg', venusSize, 15);
-    scene.add(venus);
-
-    //Earth
-    earth = createLambertMesh('assets/images/earth.jpg', earthSize, 15);
-    scene.add(earth);
-
-    //Mars
-    mars = createLambertMesh('assets/images/mars.jpg', marsSize, 15);
-    scene.add(mars);
+    //the planets
+    for (var name in planets) {
+        let data = planets[name];
+        data.mesh = createLambertMesh(`assets/images/${ name }.jpg`, data.size, data.meshSize);
+        scene.add(data.mesh)
+    }
 
     //Asteroid Belt
     asteroidBelt = new THREE.Object3D();
@@ -186,34 +197,21 @@ function init() {
         asteroidBelt.add(asteroid);
     }
 
-    //Jupiter
-    jupiter = createLambertMesh('assets/images/jupiter.jpg', jupiterSize, 25);
-    scene.add(jupiter);
-
-    //Saturn
-    saturn = createLambertMesh('assets/images/saturn.jpg', saturnSize, 25);
-    scene.add(saturn);
     //Saturn's rings
     saturnRing = createRingMesh('assets/images/saturn-ring.jpg', false, saturnRingStart, saturnRingEnd, 30);
-    saturn.add(saturnRing);
+    planets.saturn.mesh.add(saturnRing);
     saturnRing.rotation.x = 90 * Math.PI / 180;
 
-    //Uranus
-    uranus = createLambertMesh('assets/images/uranus.jpg', uranusSize, 20);
-    scene.add(uranus);
     //Uranus's rings
     uranusRing = createRingMesh('assets/images/uranus-ring.png', true, uranusRingStart, uranusRingEnd, 30);
-    uranus.add(uranusRing);
-    //Uranus' wierd positioning
-    radians = 0 * Math.PI / 180;
-    uranus.position.x = Math.cos(radians) * uranusOrbitRadius;
-    uranus.position.z = Math.sin(radians) * uranusOrbitRadius;
-    uranusRing.rotation.x = 90 * Math.PI / 180;
-    uranus.rotation.z = 90 * Math.PI / 180;
+    planets.uranus.mesh.add(uranusRing);
 
-    //Neptune
-    neptune = createLambertMesh('assets/images/neptune.jpg', neptuneSize, 20);
-    scene.add(neptune);
+    //Uranus' weird positioning
+    radians = 0 * Math.PI / 180;
+    planets.uranus.mesh.position.x = Math.cos(radians) * planets.uranus.orbitalRadius;
+    planets.uranus.mesh.position.z = Math.sin(radians) * planets.uranus.orbitalRadius;
+    uranusRing.rotation.x = 90 * Math.PI / 180;
+    planets.uranus.mesh.rotation.z = 90 * Math.PI / 180;
 
     window.addEventListener('resize', onWindowResize, false);
     renderer.domElement.addEventListener('mousemove', onMouseMove);
@@ -243,61 +241,16 @@ function render() {
     theSun.rotation.y += 0.001;
     asteroidBelt.rotation.y += 0.0001;
 
-    //run Mercury's orbit around the Sun
-    mercuryOrbitAngle -= mercuryOrbitSpeed;
-    radians = mercuryOrbitAngle * Math.PI / 180;
-    mercury.position.x = Math.cos(radians) * mercuryOrbitRadius;
-    mercury.position.z = Math.sin(radians) * mercuryOrbitRadius;
-    mercury.rotation.y += mercuryRotateSpeed;
+    for (var name in planets) {
+        let data = planets[name];
+        let mesh = data.mesh;
+        data.angle -= data.orbitalSpeed;
+        let radians = data.angle * Math.PI / 180;
 
-    //run Venus's orbit around the Sun
-    venusOrbitAngle -= venusOrbitSpeed;
-    radians = venusOrbitAngle * Math.PI / 180;
-    venus.position.x = Math.cos(radians) * venusOrbitRadius;
-    venus.position.z = Math.sin(radians) * venusOrbitRadius;
-    venus.rotation.y -= venusRotateSpeed;
-
-    //run Earth's orbit around the Sun
-    earthOrbitAngle -= earthOrbitSpeed;
-    radians = earthOrbitAngle * Math.PI / 180;
-    earth.position.x = Math.cos(radians) * earthOrbitRadius;
-    earth.position.z = Math.sin(radians) * earthOrbitRadius;
-    earth.rotation.y += earthRotateSpeed;
-
-    //run Mars's orbit around the Sun
-    marsOrbitAngle -= marsOrbitSpeed;
-    radians = marsOrbitAngle * Math.PI / 180;
-    mars.position.x = Math.cos(radians) * marsOrbitRadius;
-    mars.position.z = Math.sin(radians) * marsOrbitRadius;
-    mars.rotation.y += marsRotateSpeed;
-
-    //run Jupiter's orbit around the Sun
-    jupiterOrbitAngle -= jupiterOrbitSpeed;
-    radians = jupiterOrbitAngle * Math.PI / 180;
-    jupiter.position.x = Math.cos(radians) * jupiterOrbitRadius;
-    jupiter.position.z = Math.sin(radians) * jupiterOrbitRadius;
-    jupiter.rotation.y += jupiterRotateSpeed;
-
-    //run Saturn's orbit around the Sun
-    saturnOrbitAngle -= saturnOrbitSpeed;
-    radians = saturnOrbitAngle * Math.PI / 180;
-    saturn.position.x = Math.cos(radians) * saturnOrbitRadius;
-    saturn.position.z = Math.sin(radians) * saturnOrbitRadius;
-    saturn.rotation.y += saturnRotateSpeed;
-
-    //run Uranus's orbit around the Sun
-    uranusOrbitAngle -= uranusOrbitSpeed;
-    radians = uranusOrbitAngle * Math.PI / 180;
-    uranus.position.x = Math.cos(radians) * uranusOrbitRadius;
-    uranus.position.z = Math.sin(radians) * uranusOrbitRadius;
-    uranus.rotation.x -= uranusRotateSpeed;
-
-    //run Neptune's orbit around the Sun
-    neptuneOrbitAngle -= neptuneOrbitSpeed;
-    radians = neptuneOrbitAngle * Math.PI / 180;
-    neptune.position.x = Math.cos(radians) * neptuneOrbitRadius;
-    neptune.position.z = Math.sin(radians) * neptuneOrbitRadius;
-    neptune.rotation.y += neptuneRotateSpeed;
+        mesh.position.x = Math.cos(radians) * data.orbitalRadius;
+        mesh.position.z = Math.sin(radians) * data.orbitalRadius;
+        mesh.rotation[data.rotationAxis || 'y'] += data.rotationSpeed;
+    }
 
     renderer.render(scene, camera);
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,7 +1,6 @@
 let global = this;
 
-let THREE = global.THREE,
-    requestAnimationFrame = global.requestAnimationFrame;
+let requestAnimationFrame = global.requestAnimationFrame;
 
 let renderer, scene, camera, controls, light, radians;
 let mouse = new THREE.Vector2();

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -25,7 +25,7 @@ let planets = {
     mercury: {
         size: 1.2,
         orbitalRadius: sunSize + (AU * 0.4),
-        angle: getRandomNumber(0, 360),
+        angle: 321.21,
         orbitalSpeed: 0.8,
         rotationSpeed: 0.05,
         meshSize: 15,
@@ -33,7 +33,7 @@ let planets = {
     venus: {
         size: 3,
         orbitalRadius: sunSize + (AU * 0.7),
-        angle: getRandomNumber(0, 360),
+        angle: 191.41,
         orbitalSpeed: 0.7,
         rotationSpeed: -0.05,
         meshSize: 15,
@@ -41,7 +41,7 @@ let planets = {
     earth: {
         size: 3,
         orbitalRadius: sunSize + AU,
-        angle: getRandomNumber(0, 360),
+        angle: 24.65,
         orbitalSpeed: 0.6,
         rotationSpeed: 0.05,
         meshSize: 15,
@@ -49,7 +49,7 @@ let planets = {
     mars: {
         size: 1.6,
         orbitalRadius: sunSize + (AU * 1.5),
-        angle: getRandomNumber(0, 360),
+        angle: 304.76,
         orbitalSpeed: 0.48,
         rotationSpeed: 0.05,
         meshSize: 15,
@@ -57,7 +57,7 @@ let planets = {
     jupiter: {
         size: 34.99,
         orbitalRadius: sunSize + (AU * 5.2),
-        angle: getRandomNumber(0, 360),
+        angle: 127.59,
         orbitalSpeed: 0.26,
         rotationSpeed: 0.05,
         meshSize: 25,
@@ -65,7 +65,7 @@ let planets = {
     saturn: {
         size: 29.1,
         orbitalRadius: sunSize + (AU * 9.5),
-        angle: getRandomNumber(0, 360),
+        angle: 322.06,
         orbitalSpeed: 0.18,
         rotationSpeed: 0.05,
         meshSize: 25,
@@ -73,16 +73,16 @@ let planets = {
     uranus: {
         size: 12.7,
         orbitalRadius: sunSize + (AU * 19.2),
-        angle: getRandomNumber(0, 360),
+        angle: 110.29,
         orbitalSpeed: 0.14,
         rotationSpeed: -0.05,
         meshSize: 20,
-      rotationAxis: 'x',
+        rotationAxis: 'x',
     },
     neptune: {
         size: 12.3,
         orbitalRadius: sunSize + (AU * 30.1),
-        angle: getRandomNumber(0, 360),
+        angle: 163.24,
         orbitalSpeed: 0.1,
         rotationSpeed: 0.05,
         meshSize: 20,


### PR DESCRIPTION
I removed the duplicate declaration of the `THREE` variable, which was preventing the code from running on Firefox and Chrome.

While I was there, I consolidated the repetitive code which runs for each planet.  This might be controversial.

Finally, I set the initial planetary positions to where, to the best of my understanding, they were on 1 January, 1970.  [See here](https://omniweb.gsfc.nasa.gov/coho/helios/planet.html).

I am not an astronomer.